### PR TITLE
add a duplicate account activity page

### DIFF
--- a/app/views/account/account-activity-2.html
+++ b/app/views/account/account-activity-2.html
@@ -15,6 +15,10 @@
 <table class="govuk-table activity-table">
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Deleted proof of identity from your GOV.UK account</th>
+      <td class="govuk-table__cell">22 June 2022 at 09:25</td>
+    </tr>
+    <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Signed in to your GOV.UK account</th>
       <td class="govuk-table__cell">22 June 2022 at 09:22</td>
     </tr>

--- a/app/views/account/manage-account-2.html
+++ b/app/views/account/manage-account-2.html
@@ -67,7 +67,7 @@
 
 <h2 class="gem-c-heading govuk-heading-m">View your account activity</h2>
 <p class="govuk-body">See when you’ve signed in and how your account has used your saved information.</p>
-<p><a href="account-activity" class="govuk-link govuk-link--no-visited-state" data-module="gem-track-click" data-track-category="account-manage" data-track-action="manage-account" data-track-label="delete-account">
+<p><a href="account-activity-2" class="govuk-link govuk-link--no-visited-state" data-module="gem-track-click" data-track-category="account-manage" data-track-action="manage-account" data-track-label="delete-account">
 View your account activity</a></p>
 
 <h2 class="gem-c-heading govuk-heading-m">Delete your GOV.UK account</h2>

--- a/app/views/account/manage-account-banner.html
+++ b/app/views/account/manage-account-banner.html
@@ -80,7 +80,7 @@
 
 <h2 class="gem-c-heading govuk-heading-m">View your account activity</h2>
 <p class="govuk-body">See when you’ve signed in and how your account has used your saved information.</p>
-<p><a href="account-activity" class="govuk-link govuk-link--no-visited-state" data-module="gem-track-click" data-track-category="account-manage" data-track-action="manage-account" data-track-label="delete-account">
+<p><a href="account-activity-2" class="govuk-link govuk-link--no-visited-state" data-module="gem-track-click" data-track-category="account-manage" data-track-action="manage-account" data-track-label="delete-account">
 View your account activity</a></p>
 
 <h2 class="gem-c-heading govuk-heading-m">Delete your GOV.UK account</h2>


### PR DESCRIPTION
for journeys where users Delete the information they use to prove their identity